### PR TITLE
for 2-D data, the docstring example was correcetd. So that zsiz or nz…

### DIFF
--- a/pygeostat/data/data.py
+++ b/pygeostat/data/data.py
@@ -1294,8 +1294,8 @@ class DataFile:
 	   		.. code-block:: python
 
 				df2d = gs.ExampleData("point2d_ind")
-				df2d.infergriddef(nblk = 60)
-				df2d.infergriddef(blksize = [50,60,1])
+				df2d.infergriddef(nblk = [60, 60, None])
+				df2d.infergriddef(blksize = [50,60,None])
 		"""
 		
 		from .grid_definition import GridDef


### PR DESCRIPTION
for 2-D data, the docstring example was corrected. So that zsiz or nz must be provided as None. Otherwise it raise an exception.